### PR TITLE
AJAX for Reordering GET method changed to POST

### DIFF
--- a/core/js/admin.js
+++ b/core/js/admin.js
@@ -160,6 +160,7 @@ init: function() {
 		toleranceElement: '> div',
 		update: function() {
 			$.ETAjax({
+				type: 'POST',
 				url: "admin/channels/reorder.ajax",
 				data: {tree: $("#adminChannels .channelList").nestedSortable("toArray", {startDepthCount: -1})},
 				globalLoading: true

--- a/core/lib/ETController.class.php
+++ b/core/lib/ETController.class.php
@@ -272,8 +272,8 @@ public function init()
 
 		// If the user IS NOT logged in, add the 'login' and 'sign up' links to the bar.
 		if (!ET::$session->user) {
-			$this->addToMenu("user", "join", "<a href='".URL("user/join?return=".urlencode($this->selfURL))."' class='link-join'>".T("Sign Up")."</a>");
-			$this->addToMenu("user", "login", "<a href='".URL("user/login?return=".urlencode($this->selfURL))."' class='link-login'>".T("Log In")."</a>");
+			$this->addToMenu("user", "join", "<a href='".URL("user/join?return=".urlencode(ltrim($this->selfURL, "/index.php/")))."' class='link-join'>".T("Sign Up")."</a>");
+			$this->addToMenu("user", "login", "<a href='".URL("user/login?return=".urlencode(ltrim($this->selfURL, "/index.php/")))."' class='link-login'>".T("Log In")."</a>");
 		}
 
 		// If the user IS logged in, we want to display their name and appropriate links.


### PR DESCRIPTION
GET method will malfunction when uri request is too long. Eror 414 will occur if there are too many channels
