### PR TITLE
Better URL matching for full URLs

### DIFF
--- a/core/lib/functions.general.php
+++ b/core/lib/functions.general.php
@@ -714,7 +714,7 @@ function json_decode($json)
  */
 function URL($url = "", $absolute = false)
 {
-	if (strpos($url, "http://") === 0) return $url;
+    if (preg_match('/^(https?\:)?\/\//', $url)) return $url;
 	
 	// Strip off the hash.
 	$hash = strstr($url, "#");

--- a/core/lib/functions.general.php
+++ b/core/lib/functions.general.php
@@ -714,7 +714,7 @@ function json_decode($json)
  */
 function URL($url = "", $absolute = false)
 {
-    if (preg_match('/^(https?\:)?\/\//', $url)) return $url;
+	if (preg_match('/^(https?\:)?\/\//', $url)) return $url;
 	
 	// Strip off the hash.
 	$hash = strstr($url, "#");


### PR DESCRIPTION
Not all full URLs begin with `http://`. This regexp matches any url that begins with `https://`, `http://`, or `//` (protocol agnostic). This should cover the majority of use cases, and prevent possible derpage.
