### PR TITLE
Swap for deprecated /e argument

### DIFF
--- a/addons/plugins/Debug/geshi/geshi.php
+++ b/addons/plugins/Debug/geshi/geshi.php
@@ -2141,9 +2141,11 @@ class GeSHi {
                                 // Change the case of the word.
                                 // hackage again... must... release... 1.2...
                                 if ('smarty' == $this->language) { $hackage = '\/'; } else { $hackage = ''; }
-                                $stuff_to_parse = preg_replace(
+                                $stuff_to_parse = preg_replace_callback(
                                     "/([^a-zA-Z0-9\$_\|\#;>$hackage|^])($keyword)(?=[^a-zA-Z0-9_<\|%\-&])/ie",
-                                    "'\\1' . $func2('\\2', '$k', 'BEGIN') . '<|$styles>' . $func('\\2') . '|>' . $func2('\\2', '$k', 'END')",
+                                    function ($matches) use ($func, $func2, $styles) {
+                                        return $matches[1] . $func2($matches[2], $k, 'BEGIN') . '<|' . $styles . '>' . $func($matches[2]) . '|>' . $func2($matches[2], $k, 'END');
+                                    },
                                     $stuff_to_parse
                                 );
                             }

--- a/addons/plugins/Debug/geshi/geshi.php
+++ b/addons/plugins/Debug/geshi/geshi.php
@@ -2142,7 +2142,7 @@ class GeSHi {
                                 // hackage again... must... release... 1.2...
                                 if ('smarty' == $this->language) { $hackage = '\/'; } else { $hackage = ''; }
                                 $stuff_to_parse = preg_replace_callback(
-                                    "/([^a-zA-Z0-9\$_\|\#;>$hackage|^])($keyword)(?=[^a-zA-Z0-9_<\|%\-&])/ie",
+                                    "/([^a-zA-Z0-9\$_\|\#;>$hackage|^])($keyword)(?=[^a-zA-Z0-9_<\|%\-&])/i",
                                     function ($matches) use ($func, $func2, $styles) {
                                         return $matches[1] . $func2($matches[2], $k, 'BEGIN') . '<|' . $styles . '>' . $func($matches[2]) . '|>' . $func2($matches[2], $k, 'END');
                                     },

--- a/core/lib/ETFormat.class.php
+++ b/core/lib/ETFormat.class.php
@@ -349,7 +349,7 @@ public function removeQuotes()
 public function mentions()
 {
 	$this->content = preg_replace(
-		'/(^|[\s,\.:\]])@([^\s[\]]{3,20})\b/ieu',
+		'/(^|[\s,\.:\]])@([^\s[\]]{3,20})\b/iu',
 		"'$1<a href=\''.URL('member/name/'.urlencode(str_replace('&nbsp;', ' ', '$2')), true).'\' class=\'link-member\'>$2</a>'",
 		$this->content
 	);

--- a/core/lib/ETSQLQuery.class.php
+++ b/core/lib/ETSQLQuery.class.php
@@ -656,10 +656,15 @@ public function get()
 			$query = "";
 	}
 
+
 	// Substitute in bound parameter values.
-	$query = preg_replace('/(:[A-Za-z0-9_]+)/e', 'array_key_exists("$1", $this->parameters)
-		? ET::$database->escapeValue($this->parameters["$1"][0], $this->parameters["$1"][1])
-		: "$1"', $query);
+	$query = preg_replace_callback('/(:[A-Za-z0-9_]+)/',
+		function($matches) {
+			return array_key_exists($matches[1], $this->parameters)
+				? ET::$database->escapeValue($this->parameters[$matches[1]][0], $this->parameters[$matches[1]][1])
+				: $matches[1];
+		}, $query
+	);
 
 	return $query;
 }

--- a/core/lib/vendor/class.phpmailer.php
+++ b/core/lib/vendor/class.phpmailer.php
@@ -1603,16 +1603,15 @@ class PHPMailer {
 
     switch (strtolower($position)) {
       case 'phrase':
-        $encoded = preg_replace("/([^A-Za-z0-9!*+\/ -])/e", "'='.sprintf('%02X', ord('\\1'))", $encoded);
+        $encoded = preg_replace_callback("/([^A-Za-z0-9!*+\/ -])/", function ($matches) { return '=' . sprintf('%02X', ord($matches[1])); }, $encoded);
         break;
       case 'comment':
-        $encoded = preg_replace("/([\(\)\"])/e", "'='.sprintf('%02X', ord('\\1'))", $encoded);
+        $encoded = preg_replace_callback("/([\(\)\"])/e", function ($matches) { return '=' . sprintf('%02X', ord($matches[1])); }, $encoded);
       case 'text':
       default:
         // Replace every high ascii, control =, ? and _ characters
-        //TODO using /e (equivalent to eval()) is probably not a good idea
-        $encoded = preg_replace('/([\000-\011\013\014\016-\037\075\077\137\177-\377])/e',
-              "'='.sprintf('%02X', ord('\\1'))", $encoded);
+        $encoded = preg_replace_callback('/([\000-\011\013\014\016-\037\075\077\137\177-\377])/e',
+            function ($matches) { return '=' . sprintf('%02X', ord($matches[1])); }, $encoded);
         break;
     }
 


### PR DESCRIPTION
The `/e` modifier was deprecated in PHP55, leading to the following error being thrown in some environments:

```
Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /srv/chunksite/public/forum/core/lib/ETSQLQuery.class.php on line 662
```

This fixes that, using an anonymous function rather than an evaluation of the string.
