### PR TITLE
Fixed missing float:left on #hdr h1

### DIFF
--- a/addons/skins/Default/resources/styles.css
+++ b/addons/skins/Default/resources/styles.css
@@ -79,7 +79,7 @@ p, ul, pre {line-height:1.6em}
 /* Header */
 #hdr {background:#fff; position:fixed; width:100%; z-index:100; border-bottom:1px solid}
 #hdr-inner {padding-right:580px; white-space:nowrap}
-#hdr h1 {display:inline-block; max-width:100%; font-size:20px; padding:14px 0; margin:0; font-weight:300; overflow:hidden; white-space:nowrap; text-overflow:ellipsis}
+#hdr h1 {float:left; display:inline-block; max-width:100%; font-size:20px; padding:14px 0; margin:0; font-weight:300; overflow:hidden; white-space:nowrap; text-overflow:ellipsis}
 #hdr h1 img {display:inline; vertical-align:-5px; margin-right:5px; border:0}
 #hdr h1 span {margin-left:10px}
 #backButton {float:left; margin-right:10px; margin-left:-30px; font-size:20px; line-height:20px; margin-top:17px; text-decoration:none}


### PR DESCRIPTION
Reason:
![photo1](https://cloud.githubusercontent.com/assets/1263414/2838773/0079d6c8-d03b-11e3-97f1-2eaf213cf861.jpg)
