### PR TITLE
Changed definition warning into warning

### DIFF
--- a/addons/languages/English/definitions.php
+++ b/addons/languages/English/definitions.php
@@ -398,7 +398,7 @@ $definitions["View"] = "View";
 $definitions["Viewing: %s"] = "Viewing: %s";
 $definitions["viewingPosts"] = "<b>%s-%s</b> of %s posts";
 
-$definitions["Warning"] = "Heads Up!";
+$definitions["Warning"] = "Warning";
 $definitions["Welcome to esoTalk!"] = "Welcome to esoTalk!";
 $definitions["We've logged you in and taken you straight to your forum's administration panel. You're welcome."] = "We've logged you in and taken you straight to your forum's administration panel. You're welcome.";
 $definitions["Write a reply..."] = "Write a reply...";

--- a/addons/languages/English/definitions.php
+++ b/addons/languages/English/definitions.php
@@ -200,6 +200,7 @@ $definitions["Guests can view the:"] = "Guests can view the:";
 
 $definitions["Header"] = "Header";
 $definitions["Header color"] = "Header color";
+$definitions["Heads Up!"] = "Heads Up!";
 $definitions["Hide"] = "Hide";
 $definitions["Home page"] = "Home page";
 $definitions["HTML is allowed."] = "HTML is allowed.";

--- a/core/views/install/warnings.php
+++ b/core/views/install/warnings.php
@@ -10,7 +10,7 @@ if (!defined("IN_ESOTALK")) exit;
  * @package esoTalk
  */
 ?>
-<h1><?php echo T("Warning"); ?></h1>
+<h1><?php echo T("Heads Up!"); ?></h1>
 
 <h2>
 	<?php if (empty($data["fatal"])): echo T("message.preInstallWarnings"); ?>


### PR DESCRIPTION
I would like to propose this change partly because the Conversation Warning plugin uses T("Warning") as a label in the $controls menu and I don't find it correct to add another definitions like `$definitions["Warning2"] = "Warning";` to get the same result.
