### PR TITLE
Removed padding from .thing

### DIFF
--- a/core/skin/base.css
+++ b/core/skin/base.css
@@ -71,7 +71,7 @@ span.highlight {background:#fdef34; padding:1px 4px; border-radius:3px}
 
 
 /* "Things" - distinguishable items such as posts, activity items, plugins, and skins. */
-.thing {border:1px solid #ddd; border-radius:3px; background:#fff; padding:1px; position:relative}
+.thing {border:1px solid #ddd; border-radius:3px; background:#fff; position:relative}
 .thing:before {border-color:#ddd}
 .thing:after {border-color:#fff}
 


### PR DESCRIPTION
I am not sure why there has to be a padding. It looks ugly to me.

![screen shot 2014-04-30 at 22 10 33](https://cloud.githubusercontent.com/assets/1263414/2846551/c9bcb808-d0a3-11e3-91a2-d71ebf1f0a53.png)

vs

![screen shot 2014-04-30 at 22 10 45](https://cloud.githubusercontent.com/assets/1263414/2846552/cd5898c4-d0a3-11e3-9703-8a36be0bb8cb.png)
