### PR TITLE
Fixed follow / following start icon title

### DIFF
--- a/core/lib/functions.render.php
+++ b/core/lib/functions.render.php
@@ -279,7 +279,7 @@ function star($conversationId, $starred)
 	else {
 		$conversationId = (int)$conversationId;
 		$url = URL("conversation/star/".$conversationId."?token=".ET::$session->token."&return=".urlencode(ET::$controller->selfURL));
-		return "<a href='$url' class='starButton' title='".T("Follow")."' data-id='$conversationId'><i class='star icon-star".($starred ? "" : "-empty")."'></i></a>";
+		return "<a href='$url' class='starButton' title='".($starred ? T("Following") : T("Follow"))."' data-id='$conversationId'><i class='star icon-star".($starred ? "" : "-empty")."'></i></a>";
 	}
 }
 


### PR DESCRIPTION
Btw, I find it kinda confusing we have different definitions for the same purprose so it seems;

$definitions["Starred"] = "Following";
$definitions["Following"] = "Following";

---

also:
$definitions["Unstarred"] = "Not following";
$definitions["Follow"] = "Follow";

But not:
$definitions["Star"] = "Follow";
$definitions["Unfollow"] = "Not following";
