### PR TITLE
Honor the email.mention default pref for new users

### DIFF
--- a/core/models/ETMemberModel.class.php
+++ b/core/models/ETMemberModel.class.php
@@ -60,7 +60,7 @@ public function create(&$values)
 
 	// Set default preferences.
 	if (empty($values["preferences"])) {
-		$preferences = array("email.privateAdd", "email.post", "starOnReply");
+		$preferences = array("email.privateAdd", "email.post", "starOnReply", "email.mention");
 		foreach ($preferences as $p) {
 			$values["preferences"][$p] = C("esoTalk.preferences.".$p);
 		}


### PR DESCRIPTION
This resolves #386 where despite email.mention config being set,
new users were not getting that preference set to true.
