### PR TITLE
Fix spacing issue in BBCode parser

### DIFF
--- a/addons/plugins/BBCode/plugin.php
+++ b/addons/plugins/BBCode/plugin.php
@@ -104,7 +104,7 @@ public function handler_format_format($sender)
 	// \[ (i|b|color|url|somethingelse) \=? ([^]]+)? \] (?: ([^]]*) \[\/\1\] )
 
 	// Links with display text: [url=http://url]text[/url]
-	$sender->content = preg_replace_callback("/\[url=(\w{2,6}:\/\/)?([^\]]*?)\](.*?)\[\/url\]/i", array($this, "linksCallback"), $sender->content);
+	$sender->content = preg_replace_callback("/\[url=(?!\s+)(\w{2,6}:\/\/)?([^\]]*?)\](.*?)\[\/url\]/i", array($this, "linksCallback"), $sender->content);
 
 	// Images: [img]url[/img]
 	$replacement = $sender->inline ? "[image]" : "<img src='$1' alt='-image-'/>";


### PR DESCRIPTION
Fixes #284 - Adding spaces before & after a URL for the link BBCode causes
esoTalk to output broken HTML due to the inline link generator.  This adds
to the BBCode parser to check that there are no spaces leading the URL.
