### PR TITLE
Fix incorrect usage of date()

### DIFF
--- a/core/views/member/profile.php
+++ b/core/views/member/profile.php
@@ -35,7 +35,7 @@ if (ET::$session->isAdmin()): ?><p class='subText'><?php echo sanitizeHTML($memb
 
 <p id='memberGroup' class='subText'><?php echo memberGroup($member["account"], $member["groups"], true); ?></p>
 <p id='memberLastActive' class='subText'><?php printf(T("Last active %s"), empty($member["preferences"]["hideOnline"])
-	? "<span title='".date(T("date.full"), $member["lastActionTime"])."'>".relativeTime($member["lastActionTime"], true)."</span>"
+	? "<span title='".strftime(T("date.full"), $member["lastActionTime"])."'>".relativeTime($member["lastActionTime"], true)."</span>"
 	: "[".T("hidden")."]"); ?></p>
 
 </div>

--- a/core/views/members/member.php
+++ b/core/views/members/member.php
@@ -32,7 +32,7 @@ endif;
 
 <div class='col-lastActive'>
 <span class='subText'><?php printf(T("Last active %s"), empty($member["preferences"]["hideOnline"])
-	? "<span title='".date(T("date.full"), $member["lastActionTime"])."'>".relativeTime($member["lastActionTime"], true)."</span>"
+	? "<span title='".strftime(T("date.full"), $member["lastActionTime"])."'>".relativeTime($member["lastActionTime"], true)."</span>"
 	: "[".T("hidden")."]"); ?></span>
 </div>
 


### PR DESCRIPTION
Fixes #331 - In two instances, the date() function was used instead of
the strftime() function. This caused incorrect formatting when displaying
full date/time on member profiles.
