### PR TITLE
Protocol Relative URL Fix

### DIFF
--- a/addons/skins/Default/skin.php
+++ b/addons/skins/Default/skin.php
@@ -31,7 +31,7 @@ class ETSkin_Default extends ETSkin {
  */
 public function handler_init($sender)
 {
-	$sender->addCSSFile((C("esoTalk.https") ? "https" : "http")."://fonts.googleapis.com/css?family=Open+Sans:400,600");
+	$sender->addCSSFile((C("esoTalk.https") ? "https" : "http")."//fonts.googleapis.com/css?family=Open+Sans:400,600");
 	$sender->addCSSFile("core/skin/base.css", true);
 	$sender->addCSSFile("core/skin/font-awesome.css", true);
 	$sender->addCSSFile($this->resource("styles.css"), true);


### PR DESCRIPTION
The original call was considered unsafe on https loading sites.  This fix applies a protocol relative URL.
