### PR TITLE
correct locale specification

### DIFF
--- a/addons/languages/English/definitions.php
+++ b/addons/languages/English/definitions.php
@@ -3,7 +3,7 @@
 // This file is part of esoTalk. Please see the included license file for usage information.
 
 ET::$languageInfo["English"] = array(
-	"locale" => "en-US",
+	"locale" => "en_US",
 	"name" => "English",
 	"description" => "A casual English language pack.",
 	"version" => ESOTALK_VERSION,


### PR DESCRIPTION
I was wondering, why the scrubber did not show properly localized month names for me, but instead shows English months, even though my setup is German. I tracked it down to the locales not being specified correctly. I should of course primarily fix the German language plugin, but for consistency, it should be changed for English as well.
