### PR TITLE
make sure overriden definitions stay overriden

### DIFF
--- a/core/lib/ET.class.php
+++ b/core/lib/ET.class.php
@@ -307,7 +307,7 @@ public static function loadLanguage($language = "")
 
 	// Re-define runtime definitions.
 	foreach (self::$runtimeDefinitions as $k => $v)
-		ET::define($k, $v);
+		ET::define($k, $v, true);
 }
 
 
@@ -358,10 +358,10 @@ public static function revertLanguageState()
  */
 public static function define($key, $value, $override = false)
 {
-	self::$runtimeDefinitions[$key] = $value;
-
 	if (isset(self::$definitions[$key]) and !$override) return false;
 	self::$definitions[$key] = $value;
+
+	self::$runtimeDefinitions[$key] = $value;
 }
 
 


### PR DESCRIPTION
When a plugin, or – in my case – `custom.php` changes a definition by calling `ET::define("foo", "bar", true)`, this new definition is placed in `$runtimeDefinitions` and then becomes active, because `$override` is `true`.

However, when the language changes by way of `loadLanguage()` the definitions are replayed from `$runtimeDefinitions` without override and thus do not necessarily become effective. This patch rearranges the logic such that `$runtimeDefinitions` only captures those definitions that actually become effective when being set for the first time. Then, when a new language is loaded, those definitions are replayed with override set to `true`.

I am not quite sure about this patch and whether it will break anything else. I am using it for a while in a lightly used esoTalk installation and it fixes a problem for me: I customize some language definitions in `custom.php`, but those become ineffective when a notification mail is being sent, because there, a `loadLanguage()` occurs.
