### PR TITLE
localize post deletion timestamp

### DIFF
--- a/core/controllers/ETConversationController.class.php
+++ b/core/controllers/ETConversationController.class.php
@@ -1349,7 +1349,7 @@ public function formatPostForTemplate($post, $conversation)
 	else {
 
 		// Add the "deleted by" information.
-		if ($post["deleteMemberId"]) $formatted["controls"][] = "<span>".sprintf(T("Deleted %s by %s"), "<span title='".strftime(T("date.full"), $post["deleteTime"])."'>".relativeTime($post["deleteTime"], true)."</span>", memberLink($post["deleteMemberId"], $post["deleteMemberName"]))."</span>";
+		if ($post["deleteMemberId"]) $formatted["controls"][] = "<span>".sprintf(T("Deleted %s by %s"), "<span title='".strftime(T("date.full"), $post["deleteTime"])."' data-timestamp='".$post["deleteTime"]."'>".relativeTime($post["deleteTime"], true)."</span>", memberLink($post["deleteMemberId"], $post["deleteMemberName"]))."</span>";
 
 		// If the user can edit the post, add a restore control.
 		if ($canEdit)


### PR DESCRIPTION
The tooltip of post deletion times is not localized according to the browser locale. Other timestamps like the initial posting time or the edit time use the `data-timestamp` attribute, so I guess this has just been forgotten here.
