### PR TITLE
do not sanitizeHTML on translation strings

### DIFF
--- a/core/lib/functions.render.php
+++ b/core/lib/functions.render.php
@@ -234,7 +234,7 @@ if (!function_exists("groupName")) {
  */
 function groupName($group, $plural = false)
 {
-	return sanitizeHTML(T("group.$group".($plural ? ".plural" : ""), ucfirst($group)));
+	return T("group.$group".($plural ? ".plural" : ""), sanitizeHTML(ucfirst($group)));
 }
 
 }


### PR DESCRIPTION
I believe the translated generic group names do not need to be sanitized and in fact should not be. Otherwise I get “G&auml;ste” instead of “Gäste” shown as the German translation of the “guests” group. Thus, I changed this line so only the user-defined group names are sanitized.
