### PR TITLE
Fix extra whitespace after a code block

### DIFF
--- a/addons/plugins/BBCode/plugin.php
+++ b/addons/plugins/BBCode/plugin.php
@@ -77,7 +77,7 @@ public function handler_format_beforeFormat($sender)
 		} else {
 			$sender->content = preg_replace_callback($regexp, function ($matches) use ($self) {
 				$self->blockFixedContents[] = $matches[2];
-				return $matches[1].'</p><pre></pre></p>';
+				return $matches[1].'</p><pre></pre><p>';
 			}, $sender->content);
 		}
 	}


### PR DESCRIPTION
Fixes #436 where we were incorrectly inserting a closing p tag, when
it should have been an opening tag. This caused extra whitespace after
the end of a [/code] tag.
