### PR TITLE
Fix warnings in restricted environments

### DIFF
--- a/addons/skins/Default/views/mobile.master.php
+++ b/addons/skins/Default/views/mobile.master.php
@@ -37,7 +37,7 @@ $(function() {
 <div id='messages'>
 <?php foreach ($data["messages"] as $message): ?>
 <div class='messageWrapper'>
-<div class='message <?php echo $message["className"]; ?>' data-id='<?php echo @$message["id"]; ?>'><?php echo $message["message"]; ?></div>
+<div class='message <?php echo $message["className"]; ?>' data-id='<?php echo isset($message["id"]) ? $message["id"] : ""; ?>'><?php echo $message["message"]; ?></div>
 </div>
 <?php endforeach; ?>
 </div>

--- a/core/controllers/ETConversationController.class.php
+++ b/core/controllers/ETConversationController.class.php
@@ -360,7 +360,7 @@ public function action_start($member = false)
 	}
 
 	$channelId = $form->validPostBack("content") ? ET::$session->get("channelId") : ET::$session->get("searchChannelId");
-	ET::$session->store("channelId", isset($channels[$channelId]) ? $channelId : reset(array_keys($channels)));
+	ET::$session->store("channelId", isset($channels[$channelId]) ? $channelId : array_keys($channels)[0]);
 
 	// Get an empty conversation.
 	$model = ET::conversationModel();

--- a/core/controllers/ETConversationsController.class.php
+++ b/core/controllers/ETConversationsController.class.php
@@ -41,7 +41,10 @@ public function action_index($channelSlug = false)
 	// If the currently selected channel has no children, or if we're not including descendants, use
 	// its parent as the parent channel.
 	if (($curChannel and $curChannel["lft"] >= $curChannel["rgt"] - 1) or !$includeDescendants)
-		$curChannel = @$channelInfo[$curChannel["parentId"]];
+		if (isset($curChannel["parentId"]))
+			$curChannel = $channelInfo[$curChannel["parentId"]];
+		else
+			$curChannel = false;
 
 	// If no channel is selected, make a faux parent channel.
 	if (!$curChannel) $curChannel = array("lft" => 0, "rgt" => PHP_INT_MAX, "depth" => -1);
@@ -186,7 +189,7 @@ public function action_index($channelSlug = false)
 
 		// Add meta tags to the header.
 		$this->addToHead("<meta name='keywords' content='".sanitizeHTML(($k = C("esoTalk.meta.keywords")) ? $k : implode(",", $keywords))."'>");
-		$lastKeyword = reset(array_splice($keywords, count($keywords) - 1, 1));
+		$lastKeyword = array_splice($keywords, count($keywords) - 1, 1)[0];
 		$this->addToHead("<meta name='description' content='".sanitizeHTML(($d = C("esoTalk.meta.description")) ? $d
 			: sprintf(T("forumDescription"), C("esoTalk.forumTitle"), implode(", ", $keywords), $lastKeyword))."'>");
 

--- a/core/controllers/ETMembersController.class.php
+++ b/core/controllers/ETMembersController.class.php
@@ -103,7 +103,7 @@ public function action_index($orderBy = false, $start = 0)
 	);
 
 	// If an invalid orderBy key was provided, just use the first one.
-	if (!isset($orders[$orderBy])) $orderBy = reset(array_keys($orders));
+	if (!isset($orders[$orderBy])) $orderBy = array_keys($orders)[0];
 
 	// Work out where to start the results from.
 	$page = 0;

--- a/core/controllers/ETUserController.class.php
+++ b/core/controllers/ETUserController.class.php
@@ -324,7 +324,7 @@ public function action_sendConfirmation($username = "")
 	if (C("esoTalk.registration.requireConfirmation") != "email") return;
 
 	// Get the requested member.
-	$member = reset(ET::memberModel()->get(array("m.username" => $username, "m.confirmed" => false)));
+	$member = ET::memberModel()->get(array("m.username" => $username, "m.confirmed" => false))[0];
 	if ($member) {
 		$this->sendConfirmationEmail($member["email"], $member["username"], $member["memberId"].$member["resetPassword"]);
 		$this->renderMessage(T("Success!"), T("message.confirmEmail"));
@@ -359,7 +359,7 @@ public function action_forgot()
 	if ($form->validPostBack("submit")) {
 
 		// Find the member with this email.
-		$member = reset(ET::memberModel()->get(array("email" => $form->getValue("email"))));
+		$member = ET::memberModel()->get(array("email" => $form->getValue("email")))[0];
 		if (!$member)
 			$form->error("email", T("message.emailDoesntExist"));
 
@@ -402,7 +402,7 @@ public function action_reset($hashString = "")
 	$hash = substr($hashString, -32);
 
 	// Find the member with this password reset token. If it's an invalid token, take them back to the email form.
-	$member = reset(ET::memberModel()->get(array("m.memberId" => $memberId, "resetPassword" => $hash)));
+	$member = ET::memberModel()->get(array("m.memberId" => $memberId, "resetPassword" => $hash))[0];
 	if (!$member) return;
 
 	// Construct a form.

--- a/core/controllers/admin/ETAppearanceAdminController.class.php
+++ b/core/controllers/admin/ETAppearanceAdminController.class.php
@@ -43,7 +43,7 @@ protected function getSkins()
 	    while (false !== ($file = readdir($handle))) {
 
 			// Make sure the skin is valid, and include its skin.php file.
-	        if ($file[0] != "." and file_exists($skinFile = PATH_SKINS."/$file/skin.php") and (include_once $skinFile)) {
+	        if ($file[0] != "." and $file != "index.html" and file_exists($skinFile = PATH_SKINS."/$file/skin.php") and (include_once $skinFile)) {
 
 	        	// Add the skin's information and status to the array.
 				$skins[$file] = array(

--- a/core/controllers/admin/ETAppearanceAdminController.class.php
+++ b/core/controllers/admin/ETAppearanceAdminController.class.php
@@ -141,8 +141,8 @@ public function action_uninstall($skin = "")
 
 	// If one of the skin config options is set to this skin, change it.
 	$config = array();
-	if (C("esoTalk.skin") == $skin) $config["esoTalk.skin"] = reset(array_keys($skins));
-	if (C("esoTalk.mobileSkin") == $skin) $config["esoTalk.mobileSkin"] = reset(array_keys($skins));
+	if (C("esoTalk.skin") == $skin) $config["esoTalk.skin"] = array_keys($skins)[0];
+	if (C("esoTalk.mobileSkin") == $skin) $config["esoTalk.mobileSkin"] = array_keys($skins)[0];
 	if (count($config)) ET::writeConfig($config);
 
 	$this->redirect(URL("admin/appearance"));

--- a/core/controllers/admin/ETPluginsAdminController.class.php
+++ b/core/controllers/admin/ETPluginsAdminController.class.php
@@ -39,7 +39,7 @@ protected function getPlugins()
 	    while (false !== ($file = readdir($handle))) {
 
 			// Make sure the plugin is valid, and include its plugin.php file.
-	        if ($file[0] != "." and file_exists($pluginFile = PATH_PLUGINS."/$file/plugin.php") and (include_once $pluginFile)) {
+	        if ($file[0] != "." and $file != "index.html" and file_exists($pluginFile = PATH_PLUGINS."/$file/plugin.php") and (include_once $pluginFile)) {
 
 				// Add the plugin's information and status to the array.
 				$plugins[$file] = array(

--- a/core/lib/ET.class.php
+++ b/core/lib/ET.class.php
@@ -390,7 +390,7 @@ public static function getLanguages()
 	if ($handle = opendir(PATH_LANGUAGES)) {
 	    while (false !== ($file = readdir($handle))) {
 
-	        if ($file[0] != "." and file_exists($defs = PATH_LANGUAGES."/$file/definitions.php")) {
+	        if ($file[0] != "." and $file != "index.html" and file_exists($defs = PATH_LANGUAGES."/$file/definitions.php")) {
 
 	        	// Include the file so we get the language information in ET::$languageInfo.
 	        	include_once $defs;

--- a/core/lib/ETFormat.class.php
+++ b/core/lib/ETFormat.class.php
@@ -221,10 +221,10 @@ public function linksCallback($matches)
 	// then return an embed tag.
 	if (!$this->inline and C("esoTalk.format.youtube") and preg_match('%(?:youtube(?:-nocookie)?\.com/(?:[^/]+/.+/|(?:v|e(?:mbed)?)/|.*(?:\?|&amp;)v=)|youtu\.be/)([^"&?/ ]{11})(?:(?:\?|&amp;)(.*))?%i', $matches[2], $youtube)) {
 		$id = $youtube[1];
-		$options = $youtube[2];
+		$options = isset($youtube[2]) ? "?" . $youtube[2] : "";
 		$width = 400;
 		$height = 225;
-		return "<iframe class='video' type='text/html' width='$width' height='$height' src='https://www.youtube-nocookie.com/embed/$id?$options' allowfullscreen frameborder='0'></iframe>";
+		return "<iframe class='video' type='text/html' width='$width' height='$height' src='https://www.youtube-nocookie.com/embed/$id$options' allowfullscreen frameborder='0'></iframe>";
 	}
 	if (!$this->inline and C("esoTalk.format.vimeo") and preg_match('%(?:vimeo\.com/)([0-9]+)%i', $matches[2], $vimeo)) {
 		$id = $vimeo[1];

--- a/core/lib/ETModel.class.php
+++ b/core/lib/ETModel.class.php
@@ -180,7 +180,7 @@ public function get($wheres = array())
  */
 public function getById($id)
 {
-	return reset($this->get(array($this->primaryKey => $id)));
+	return $this->get(array($this->primaryKey => $id))[0];
 }
 
 

--- a/core/lib/ETSession.class.php
+++ b/core/lib/ETSession.class.php
@@ -178,7 +178,7 @@ public function login($name, $password, $remember = false)
 		->where("m.username=:username OR m.email=:email")
 		->bind(":username", $name)
 		->bind(":email", $name);
-	$member = reset(ET::memberModel()->getWithSQL($sql));
+	$member = ET::memberModel()->getWithSQL($sql)[0];
 
 	// Check that the password is correct.
 	if (!$member or !ET::memberModel()->checkPassword($password, $member["password"])) {

--- a/core/lib/functions.general.php
+++ b/core/lib/functions.general.php
@@ -126,9 +126,10 @@ function rrmdir($dir)
  * @package esoTalk
  */
 function file_force_contents($file, $contents){
+	$file = str_replace(PATH_ROOT, '', $file);
 	$parts = explode("/", $file);
 	$file = array_pop($parts);
-	$dir = "";
+	$dir = PATH_ROOT;
 	foreach($parts as $part)
 		if (!is_dir($dir .= "$part/")) mkdir($dir);
 	return file_put_contents("$dir$file", $contents);

--- a/core/models/ETMemberModel.class.php
+++ b/core/models/ETMemberModel.class.php
@@ -166,7 +166,7 @@ public function getWithSQL($sql)
  */
 public function getById($memberId)
 {
-	return reset($this->get(array("m.memberId" => $memberId)));
+	return $this->get(array("m.memberId" => $memberId))[0];
 }
 
 

--- a/core/models/ETPostModel.class.php
+++ b/core/models/ETPostModel.class.php
@@ -100,7 +100,7 @@ public function get($wheres = array())
  */
 public function getById($postId)
 {
-	return reset($this->get(array("p.postId" => $postId)));
+	return $this->get(array("p.postId" => $postId))[0];
 }
 
 

--- a/core/views/default.master.php
+++ b/core/views/default.master.php
@@ -24,7 +24,7 @@ if (!defined("IN_ESOTALK")) exit;
 <div id='messages'>
 <?php foreach ($data["messages"] as $message): ?>
 <div class='messageWrapper'>
-<div class='message <?php echo $message["className"]; ?>' data-id='<?php echo @$message["id"]; ?>'><?php echo $message["message"]; ?></div>
+<div class='message <?php echo $message["className"]; ?>' data-id='<?php echo isset($message["id"]) ? $message["id"] : ""; ?>'><?php echo $message["message"]; ?></div>
 </div>
 <?php endforeach; ?>
 </div>


### PR DESCRIPTION
This is probably a controversial pull request, but I decided to suggest it anyways. I am developing an esoTalk forum app for Nextcloud [over here](https://github.com/mroi/nextcloud-esotalk). (*)

Unfortunately, Nextcloud runs PHP with strict error reporting and I additionally add `open_basedir` restrictions on top. The first patch in this pull request fixes many warnings esoTalk emits with PHP strict reporting. The second patch fixes warnings due to `open_basedir`. These should have no particular effect on standard esoTalk installations, since I (hopefully) did not change any code semantics.

The only limitation I can see is that the array indexing for function returns only works with PHP 5.4 and above. So feel free to reject this pull request or cherry-pick from it. Or ask me questions for particular changes.

(*) I know that I will have to transition to Flarum in the near future, but I am maintaining this anyways, because it is in active use for a project I manage.