### PR TITLE
create fulltext index of post content

### DIFF
--- a/core/models/ETUpgradeModel.class.php
+++ b/core/models/ETUpgradeModel.class.php
@@ -221,6 +221,7 @@ protected function structure($drop = false)
 		->key("memberId")
 		->key(array("conversationId", "time"))
 		->key(array("title", "content"), "fulltext")
+		->key(array("content"), "fulltext")
 		->exec($drop);
 
 	// Search table.


### PR DESCRIPTION
Searching within a conversation issues a `MATCH` clause on the `content` column (see [ETPostModel](../blob/develop/core/models/ETPostModel.class.php#L173)). However, no fulltext index is configured for `content`, leading to this database error:

    SQL Error (HY000, 1191): Can't find FULLTEXT index matching the column list

Searching over all conversations matches on `content` and `title` for which a fulltext index exists. This patch adds a fulltext index for `content` alone.